### PR TITLE
Have bash provide /bin/sh instead of dash

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
+sudo rm -f /bin/sh
+sudo ln -s /bin/bash /bin/sh
+
 sudo apt-get update


### PR DESCRIPTION
Since bash is already the default shell on this VM, let's have it provide /bin/sh
instead of the current default (dash). That way we avoid weird inconsistencies
(such as when using Sys.command in OCaml, which invokes via /bin/sh).

Note that this still will not be the same as standard bash - when invoked via a
symlink through /bin/sh bash will enter POSIX mode. But at least it's still
closer than using a completely different shell.