### PR TITLE
utop: Add `utoprc` from cs3110-tools

### DIFF
--- a/setup-opam.sh
+++ b/setup-opam.sh
@@ -31,3 +31,5 @@ alias ocaml=utop
 
 EOF
 
+cp 3110-tools/config/utoprc ~/.utoprc
+


### PR DESCRIPTION
See https://github.com/cs3110/vagrant-opam/issues/2 for more details.